### PR TITLE
Quick and dirty fix for flatpickr

### DIFF
--- a/app/views/company/bookings/_navbar_dashboard.html.erb
+++ b/app/views/company/bookings/_navbar_dashboard.html.erb
@@ -14,7 +14,7 @@
               <%= link_to "Dashboard", company_dashboard_path, class: "nav-link" %>
             </li>
             <li class="nav-item">
-              <%= link_to "Bookings", company_bookings_path, class: "nav-link" %>
+              <%= link_to "Bookings", company_bookings_path, class: "nav-link", data: { turbolinks: false } %>
             </li>
             <li class="nav-item">
               <%= link_to "Trips", company_dashboard_path, class: "nav-link" %>


### PR DESCRIPTION
## Changelog

### Bugfix
Using the navbar link for the bookings filter does not load flatpickr (javascript plugin). This was fixed (for now) by disabling turbolinks for that specific link.