### PR TITLE
Bugfix: No cocaine for home page

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -36,8 +36,9 @@
         var text = ["SUN", "SEA", "DIVE", "PARADISE"];
         var counter = 0;
         var elem = document.getElementById("change");
-        var inst = setInterval(change, 2500);
-
+        if (!inst) {
+          var inst = setInterval(change, 2500);
+        }
         function change() {
           elem.innerHTML = text[counter];
           counter++;


### PR DESCRIPTION
## Changes

### Home page banner animation gets on cocaine if user reloads or backs

#### Fix
- Intervals spawned by setInterval() don't get automatically de-spawned if using turbolinks. What was happening is that on each page load a new interval was being spawned alongside the others. Because the script changes which word appears on the HTML element for every interval 'tick', multiple intervals where producing multiple 'ticks' and the banner was changing rapidly.
- The simplest fix was to code a conditional, if the interval still exists, then the script does not spawn another one. This guarantees that only one interval will be running in a given page load.

#### Fixed behavior
- Banner now changes text in a controlled manner even with turbolinks loads (e.g. using the Home button in the navbar or the back button on the browser).